### PR TITLE
Generator Error UX Improvements

### DIFF
--- a/app/generator/page.tsx
+++ b/app/generator/page.tsx
@@ -20,6 +20,7 @@ import ResultsSkeleton from "@/components/ui/results-skeleton";
 import Skeleton from "@/components/ui/skeleton";
 import { toast } from "@/components/ui/use-toast";
 import { friendlyGenerationError } from "@/lib/generator-errors";
+import { HardeningAlert } from "@/components/generator/hardening-alert";
 import { SaveSchemaDialog } from "@/components/generator/save-schema-dialog";
 import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
@@ -227,6 +228,13 @@ function GeneratorPageContent() {
   );
   const [tempInstructions, setTempInstructions] = useState("");
 
+  // Inline alert for prompt-hardening rejections (shown above the Generate
+  // button; non-hardening errors continue to use toasts).
+  const [hardeningError, setHardeningError] = useState<{
+    title: string;
+    description: string;
+  } | null>(null);
+
   // Reference to DailyLimitInfo component
   const dailyLimitRef = useRef<{ refreshUsage: () => Promise<void> } | null>(
     null
@@ -408,6 +416,8 @@ function GeneratorPageContent() {
       setGenerationController(controller);
       setIsGenerating(true);
       setResults("");
+      // Clear any previous hardening alert when a new attempt starts.
+      setHardeningError(null);
       setProgressStep("parsing");
       setProgressPercent(8);
       setProgressMessage("Validating schema and configuration...");
@@ -568,31 +578,39 @@ function GeneratorPageContent() {
         if (!response.ok) {
           let errorMsg = `Error ${response.status}: ${response.statusText}`;
           let errorTitle = `Generation Failed (${response.status})`;
+          let errorKind: "hardening" | "limit" | "other" = "other";
 
           try {
             const errorData = await response.json();
             const friendly = friendlyGenerationError(response.status, errorData);
             errorTitle = friendly.title;
             errorMsg = friendly.description;
+            errorKind = friendly.kind;
           } catch (parseError) {
             console.error("Failed to parse error response:", parseError);
           }
 
-          toast({
-            title: errorTitle,
-            description: errorMsg,
-            variant: "destructive",
-            action:
-              status === "authenticated" ? (
-                <Button
-                  variant="link"
-                  className="text-sm underline"
-                  onClick={() => router.push("/dashboard/events")}
-                >
-                  View details in dashboard
-                </Button>
-              ) : undefined,
-          });
+          if (errorKind === "hardening") {
+            // Inline alert above the Generate button — keeps the user's
+            // attention on the field they need to edit.
+            setHardeningError({ title: errorTitle, description: errorMsg });
+          } else {
+            toast({
+              title: errorTitle,
+              description: errorMsg,
+              variant: "destructive",
+              action:
+                status === "authenticated" ? (
+                  <Button
+                    variant="link"
+                    className="text-sm underline"
+                    onClick={() => router.push("/dashboard/events")}
+                  >
+                    View details in dashboard
+                  </Button>
+                ) : undefined,
+            });
+          }
 
           throw new Error(errorMsg);
         }
@@ -960,6 +978,15 @@ function GeneratorPageContent() {
                   />
                 </div>
               </CardFooter>
+              {hardeningError && (
+                <div className="px-4 sm:px-6 pt-2">
+                  <HardeningAlert
+                    title={hardeningError.title}
+                    description={hardeningError.description}
+                    onDismiss={() => setHardeningError(null)}
+                  />
+                </div>
+              )}
               <div className="p-4 pt-4 pb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:p-6">
                 <Button
                   onClick={handleGenerate}

--- a/components/generator/hardening-alert.tsx
+++ b/components/generator/hardening-alert.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import { ShieldAlert, ChevronDown, X } from "lucide-react";
+import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
+import { cn } from "@/lib/utils";
+
+interface HardeningAlertProps {
+  title: string;
+  description: string;
+  /** Called when the user dismisses the alert. */
+  onDismiss?: () => void;
+  className?: string;
+}
+
+/**
+ * Inline alert shown above the Generate button when the server rejects a
+ * request via one of the prompt-hardening gates (400 jailbreak / off-topic,
+ * 422 off-topic refusal, 429 concurrency cap, etc).
+ *
+ * Title is always visible; description starts collapsed and expands on click.
+ */
+export function HardeningAlert({
+  title,
+  description,
+  onDismiss,
+  className,
+}: HardeningAlertProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Alert
+      variant="destructive"
+      className={cn("pl-4 pr-3 py-3", className)}
+      role="alert"
+      aria-live="polite"
+    >
+      <div className="flex items-start gap-3">
+        <ShieldAlert className="h-5 w-5 shrink-0 mt-0.5" aria-hidden="true" />
+        <div className="flex-1 min-w-0">
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            aria-expanded={open}
+            aria-controls="hardening-alert-description"
+            className="flex w-full items-center justify-between gap-2 text-left"
+          >
+            <AlertTitle className="mb-0">{title}</AlertTitle>
+            <ChevronDown
+              className={cn(
+                "h-4 w-4 shrink-0 transition-transform",
+                open && "rotate-180"
+              )}
+              aria-hidden="true"
+            />
+          </button>
+          <AlertDescription
+            id="hardening-alert-description"
+            className={cn(
+              "grid transition-all duration-200",
+              open ? "grid-rows-[1fr] mt-2 opacity-100" : "grid-rows-[0fr] opacity-0"
+            )}
+          >
+            <p className="overflow-hidden">{description}</p>
+          </AlertDescription>
+        </div>
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label="Dismiss"
+            className="shrink-0 rounded-md p-1 text-destructive/80 hover:bg-destructive/10 hover:text-destructive transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+    </Alert>
+  );
+}

--- a/lib/generator-errors.ts
+++ b/lib/generator-errors.ts
@@ -17,6 +17,14 @@ export interface GeneratorErrorBody {
 export interface FriendlyError {
   title: string;
   description: string;
+  /**
+   * "hardening" — rejected by our prompt-security / SSRF / concurrency gates.
+   *   These are surfaced inline above the Generate button so the user can
+   *   immediately edit their input and retry without losing focus.
+   * "limit" — daily quota or auth issues; toast is still appropriate.
+   * "other" — server, network, or unknown; toast.
+   */
+  kind: "hardening" | "limit" | "other";
 }
 
 export function friendlyGenerationError(
@@ -30,19 +38,22 @@ export function friendlyGenerationError(
   if (status === 422) {
     if (reason === "off_topic_refusal") {
       return {
+        kind: "hardening",
         title: "Request not recognised as a mock-data ask",
         description:
-          "The model didn't recognise this as a request for synthetic records. Try a clearer schema or example, then generate again. This attempt does not count against your daily quota.",
+          "The model didn't recognise this as a request for synthetic records. Try a clearer schema or example, then generate again.",
       };
     }
     if (reason === "sql_dangerous_statement") {
       return {
+        kind: "hardening",
         title: "Generated SQL was rejected",
         description:
           "The generated output contained SQL statements outside the allowed INSERT set. Try regenerating, or switch the output format to JSON or CSV.",
       };
     }
     return {
+      kind: "hardening",
       title: "Generation refused",
       description:
         "The request was refused by our content checks. Adjust the schema or examples and try again.",
@@ -53,12 +64,14 @@ export function friendlyGenerationError(
   if (status === 429) {
     if (reason === "concurrency_limit") {
       return {
+        kind: "hardening",
         title: "Too many concurrent generations",
         description:
           "You already have generations in flight. Wait for them to finish, then try again.",
       };
     }
     return {
+      kind: "limit",
       title: "Daily limit reached",
       description:
         body?.error ||
@@ -69,6 +82,7 @@ export function friendlyGenerationError(
   // 403 — daily limit on /api/generate uses 403, not 429.
   if (status === 403) {
     return {
+      kind: "limit",
       title: "Daily limit reached",
       description:
         body?.error ||
@@ -79,14 +93,21 @@ export function friendlyGenerationError(
   // 400 — pre-flight intent check, BYO-key gate, SSRF guard, or zod failure.
   if (status === 400) {
     if (reason === "jailbreak_phrase" || reason === "off_topic") {
-      const where = field === "examples" ? "Examples" : field === "additionalInstructions" ? "Additional Instructions" : "your input";
+      const where =
+        field === "examples"
+          ? "Examples"
+          : field === "additionalInstructions"
+            ? "Additional Instructions"
+            : "your input";
       return {
+        kind: "hardening",
         title: "Request looks off-topic",
         description: `${where} contains wording that doesn't fit a mock-data request. Rephrase it as a description of the records you want, then try again.`,
       };
     }
     if (reason === "byo_key_required") {
       return {
+        kind: "hardening",
         title: "Additional Instructions need your own key",
         description:
           "Save your own AI provider API key in Settings and toggle “Use My API Key” to use additional instructions, or remove that field and retry.",
@@ -94,12 +115,14 @@ export function friendlyGenerationError(
     }
     if (body?.details) {
       return {
+        kind: "hardening",
         title: "Invalid request",
         description:
           "Some fields didn't pass validation (length, type, or range). Check your schema, examples, and limits, then try again.",
       };
     }
     return {
+      kind: "hardening",
       title: "Request rejected",
       description:
         body?.error ||
@@ -110,6 +133,7 @@ export function friendlyGenerationError(
   // 401 — auth (rare on /api/generate).
   if (status === 401) {
     return {
+      kind: "limit",
       title: "Sign-in required",
       description: "Please sign in and try again.",
     };
@@ -118,6 +142,7 @@ export function friendlyGenerationError(
   // 5xx — server problem.
   if (status >= 500) {
     return {
+      kind: "other",
       title: "Service problem",
       description:
         "Something went wrong on our end while generating. Please try again in a moment.",
@@ -126,6 +151,7 @@ export function friendlyGenerationError(
 
   // Fallback.
   return {
+    kind: "other",
     title: `Generation Failed (${status})`,
     description: body?.error || body?.message || "Unexpected error. Please try again.",
   };


### PR DESCRIPTION
# Generator Error UX Improvements

## Summary

This branch polishes the error messaging experience, derived from the hardened prompt security measures previously implemented:

1. **Friendly, status-aware error messages** — a single mapper turns the structured `error` / `reason` / `field` payloads from `/api/generate` into user-readable copy that doesn't leak which specific filter fired.
2. **Inline hardening alert above the Generate button** — prompt-security rejections (400 jailbreak/off-topic, 422 off-topic refusal, 429 concurrency cap, etc.) now render in-card next to the user's input rather than as a transient toast. The alert has an error icon, an always-visible title, and a click-to-expand description; the user can dismiss it explicitly.

---


### Friendly error mapper

**Why.** The route returns structured fields (`error`, `reason`, `field`, `details`) but the UI was previously reading only `errorData.message` and falling back to status text. That meant our new 400/422/429 responses surfaced as `Error 422: Unprocessable Entity` — useless to the user.

**Implementation** (`lib/generator-errors.ts`):

- Single function `friendlyGenerationError(status, body) → { title, description, kind }`.
- `kind: "hardening" | "limit" | "other"` lets the UI decide where to show the message:
  - `hardening` → inline alert above the Generate button (component below).
  - `limit` → toast (daily-quota / auth, where the user typically expects a transient notification).
  - `other` → toast (server errors, network, unknown).
- Messages are **deliberately generic** — they tell the user which field is wrong (`Examples`, `Additional Instructions`) without echoing the matched phrase or naming the heuristic. Maintainers see the precise reason in server logs.

Status / reason coverage:

| Status / reason | Kind | Title |
|---|---|---|
| 422 `off_topic_refusal` | hardening | Request not recognised as a mock-data ask |
| 422 `sql_dangerous_statement` | hardening | Generated SQL was rejected |
| 422 (other) | hardening | Generation refused |
| 429 `concurrency_limit` | hardening | Too many concurrent generations |
| 429 (other) | limit | Daily limit reached |
| 403 | limit | Daily limit reached |
| 400 `jailbreak_phrase` / `off_topic` | hardening | Request looks off-topic |
| 400 `byo_key_required` | hardening | Additional Instructions need your own key |
| 400 with `details` | hardening | Invalid request |
| 400 (other) | hardening | Request rejected |
| 401 | limit | Sign-in required |
| 5xx | other | Service problem |
| fallback | other | Generation Failed (`<status>`) |

###  Inline hardening alert

**Why.** Toasts are wrong for hardening errors because:

- They disappear after a few seconds, so the user can't easily re-read what they need to fix.
- They appear in the corner, away from the input field they need to edit.
- They get drowned out if the user retries and triggers a second toast.

A persistent, dismissible inline alert next to the Generate button keeps the user's attention on the field they need to change and stays visible until they fix it or dismiss it.

**Implementation** (`components/generator/hardening-alert.tsx`):

## Files added

| File | Purpose |
|---|---|
| `lib/generator-errors.ts` | `friendlyGenerationError(status, body) → { title, description, kind }` mapper |
| `components/generator/hardening-alert.tsx` | Inline collapsible alert for prompt-hardening rejections |

